### PR TITLE
Don't show the no symptoms confirmation dialog if no symptoms are selected 

### DIFF
--- a/app/src/main/java/uk/nhs/nhsx/covid19/android/app/questionnaire/selection/QuestionnaireActivity.kt
+++ b/app/src/main/java/uk/nhs/nhsx/covid19/android/app/questionnaire/selection/QuestionnaireActivity.kt
@@ -129,12 +129,24 @@ class QuestionnaireActivity : BaseActivity(R.layout.activity_questionnaire) {
         }
 
         textNoSymptoms.setOnClickListener {
-            viewModel.onButtonCancelClicked {
-                finish()
-                startActivity<NoSymptomsActivity>()
+            if (viewModel.getQuestionsChecked()) {
+                AlertDialog.Builder(this)
+                .setTitle(R.string.questionnaire_discard_symptoms_dialog_title)
+                .setMessage(R.string.questionnaire_discard_symptoms_dialog_message)
+                .setNegativeButton(R.string.cancel) { dialog, _ ->
+                    dialog.dismiss()
+                }
+                .setPositiveButton(R.string.remove) { _, _ ->
+                    finish()
+                    startActivity<NoSymptomsActivity>()
+                }
+                .show()
+            } else {
+               finish()
+               startActivity<NoSymptomsActivity>()
             }
         }
-
+        
         buttonReviewSymptoms.setOnClickListener {
             viewModel.onButtonReviewSymptomsClicked()
         }

--- a/app/src/main/java/uk/nhs/nhsx/covid19/android/app/questionnaire/selection/QuestionnaireActivity.kt
+++ b/app/src/main/java/uk/nhs/nhsx/covid19/android/app/questionnaire/selection/QuestionnaireActivity.kt
@@ -129,17 +129,10 @@ class QuestionnaireActivity : BaseActivity(R.layout.activity_questionnaire) {
         }
 
         textNoSymptoms.setOnClickListener {
-            AlertDialog.Builder(this)
-                .setTitle(R.string.questionnaire_discard_symptoms_dialog_title)
-                .setMessage(R.string.questionnaire_discard_symptoms_dialog_message)
-                .setNegativeButton(R.string.cancel) { dialog, _ ->
-                    dialog.dismiss()
-                }
-                .setPositiveButton(R.string.remove) { _, _ ->
-                    finish()
-                    startActivity<NoSymptomsActivity>()
-                }
-                .show()
+            viewModel.onButtonCancelClicked {
+                finish()
+                startActivity<NoSymptomsActivity>()
+            }
         }
 
         buttonReviewSymptoms.setOnClickListener {

--- a/app/src/main/java/uk/nhs/nhsx/covid19/android/app/questionnaire/selection/QuestionnaireViewModel.kt
+++ b/app/src/main/java/uk/nhs/nhsx/covid19/android/app/questionnaire/selection/QuestionnaireViewModel.kt
@@ -81,6 +81,25 @@ class QuestionnaireViewModel @Inject constructor(
         }
     }
 
+    fun onButtonCancelClicked(noSymptomsCallback: () -> Unit) {
+        val questions = getQuestions() ?: return
+        if (questions.any { it.isChecked }) {
+            AlertDialog.Builder(this)
+                .setTitle(R.string.questionnaire_discard_symptoms_dialog_title)
+                .setMessage(R.string.questionnaire_discard_symptoms_dialog_message)
+                .setNegativeButton(R.string.cancel) { dialog, _ ->
+                    dialog.dismiss()
+                }
+                .setPositiveButton(R.string.remove) { _, _ ->
+                    noSymptomsCallback()
+                }
+                .show()
+        } else {
+            noSymptomsCallback()
+        }
+        
+    }
+
     private fun getQuestions(): List<Question>? {
         val result = viewState.value
         if (result is Lce.Success) {

--- a/app/src/main/java/uk/nhs/nhsx/covid19/android/app/questionnaire/selection/QuestionnaireViewModel.kt
+++ b/app/src/main/java/uk/nhs/nhsx/covid19/android/app/questionnaire/selection/QuestionnaireViewModel.kt
@@ -81,23 +81,8 @@ class QuestionnaireViewModel @Inject constructor(
         }
     }
 
-    fun onButtonCancelClicked(noSymptomsCallback: () -> Unit) {
-        val questions = getQuestions() ?: return
-        if (questions.any { it.isChecked }) {
-            AlertDialog.Builder(this)
-                .setTitle(R.string.questionnaire_discard_symptoms_dialog_title)
-                .setMessage(R.string.questionnaire_discard_symptoms_dialog_message)
-                .setNegativeButton(R.string.cancel) { dialog, _ ->
-                    dialog.dismiss()
-                }
-                .setPositiveButton(R.string.remove) { _, _ ->
-                    noSymptomsCallback()
-                }
-                .show()
-        } else {
-            noSymptomsCallback()
-        }
-        
+    fun getQuestionsChecked(): Boolean {
+        questions.any { it.isChecked }
     }
 
     private fun getQuestions(): List<Question>? {


### PR DESCRIPTION
The dialog that states "Any selected symptoms will be unselected" is a little confusing when no symptoms are selected. This PR removes it when no symptoms are selected. The change is speculative as I haven't built the app, and also hasn't updated the relevant test which I believe will fail at https://github.com/nhsx/covid-19-app-android-ag-public/blob/01f790a0ebefe20ba6ff7925e56dfd88911741bf/app/src/androidTestScenarios/java/uk/nhs/nhsx/covid19/android/app/questionnaire/QuestionnaireScenarioTest.kt#L188 and https://github.com/nhsx/covid-19-app-android-ag-public/blob/01f790a0ebefe20ba6ff7925e56dfd88911741bf/app/src/androidTestScenarios/java/uk/nhs/nhsx/covid19/android/app/questionnaire/QuestionnaireScenarioTest.kt#L213